### PR TITLE
linker error and email address

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 INSTALLDIR=/etc/zabbix/externalscripts
 
-PKG_CONFIG=libpcre libcurl libssl
+PKG_CONFIG=libpcre libcurl libssl libcrypto
 PKG_CFLAGS=$(shell pkg-config --cflags $(PKG_CONFIG))
 PKG_LDFLAGS=$(shell pkg-config --libs-only-L $(PKG_CONFIG))
 PKG_LDFLAGS_STATIC=$(shell pkg-config --static --libs-only-L $(PKG_CONFIG))

--- a/README.md
+++ b/README.md
@@ -160,6 +160,6 @@ Additional authors are very welcome - just submit your patches as pull requests.
  * Marc Schoechlin <ms@256bit.org>
  * Marc Schoechlin <marc.schoechlin@dmc.de>
  * Marc Schoechlin <marc.schoechlin@breuninger.de>
- * Andreas Heil <andreas.heil@dmc.de>
+ * Andreas Heil <ah@linux-hq.de>
 
 License - see: LICENSE.txt


### PR DESCRIPTION
1. Fix for linker error
```
gcc -o http_extend main.o callback.o  -lpcre -lcurl -lssl  
/usr/bin/ld: main.o: undefined reference to symbol 'X509_STORE_CTX_get_error_depth@@OPENSSL_1.0.0'
//lib/x86_64-linux-gnu/libcrypto.so.1.0.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
Makefile:41: recipe for target 'http_extend' failed
make: *** [http_extend] Error 1
```

2. my email address is wrong